### PR TITLE
Add user orders endpoint

### DIFF
--- a/OrderService/OrderService.Application/Handlers/GetOrdersByUserIdQueryHandler.cs
+++ b/OrderService/OrderService.Application/Handlers/GetOrdersByUserIdQueryHandler.cs
@@ -1,0 +1,32 @@
+using MediatR;
+using OrderService.Application.DTO;
+using OrderService.Application.Queries;
+using OrderService.Domain.Repositories;
+
+namespace OrderService.Application.Handlers
+{
+    public sealed class GetOrdersByUserIdQueryHandler
+        : IRequestHandler<GetOrdersByUserIdQuery, List<OrderDto>>
+    {
+        private readonly IOrderRepository _repo;
+        public GetOrdersByUserIdQueryHandler(IOrderRepository repo) => _repo = repo;
+
+        public async Task<List<OrderDto>> Handle(GetOrdersByUserIdQuery query, CancellationToken ct)
+        {
+            var orders = await _repo.GetByUserIdAsync(query.UserId);
+            return orders.Select(o => new OrderDto
+            {
+                Id = o.Id,
+                UserId = o.UserId,
+                OrderDate = o.OrderDate,
+                Status = o.Status,
+                Items = o.OrderItems.Select(i => new OrderItemDto
+                {
+                    ProductId = i.ProductId,
+                    Quantity = i.Quantity,
+                    UnitPrice = i.UnitPrice
+                }).ToList()
+            }).ToList();
+        }
+    }
+}

--- a/OrderService/OrderService.Application/Queries/GetOrdersByUserIdQuery.cs
+++ b/OrderService/OrderService.Application/Queries/GetOrdersByUserIdQuery.cs
@@ -1,0 +1,9 @@
+using MediatR;
+using OrderService.Application.DTO;
+using System;
+using System.Collections.Generic;
+
+namespace OrderService.Application.Queries
+{
+    public sealed record GetOrdersByUserIdQuery(Guid UserId) : IRequest<List<OrderDto>>;
+}

--- a/OrderService/OrderService.Domain/Repositories/IOrderRepository.cs
+++ b/OrderService/OrderService.Domain/Repositories/IOrderRepository.cs
@@ -10,6 +10,7 @@ namespace OrderService.Domain.Repositories
         Task AddAsync(Order order);
         Task<Order?> GetByIdAsync(Guid id);
         Task<List<Order>> GetAllAsync();
+        Task<List<Order>> GetByUserIdAsync(Guid userId);
         Task DeleteAsync(Guid id);
         Task SaveChangesAsync();
     }

--- a/OrderService/OrderService.Infrastructure/Repositories/OrderRepository.cs
+++ b/OrderService/OrderService.Infrastructure/Repositories/OrderRepository.cs
@@ -31,6 +31,12 @@ namespace OrderService.Infrastructure.Repositories
                      .Include(o => o.OrderItems)
                      .ToListAsync();
 
+        public async Task<List<Order>> GetByUserIdAsync(Guid userId) =>
+            await _db.Orders
+                     .Include(o => o.OrderItems)
+                     .Where(o => o.UserId == userId)
+                     .ToListAsync();
+
         public async Task DeleteAsync(Guid id)
         {
             var order = await _db.Orders.FindAsync(id);

--- a/OrderService/OrderService/Controllers/OrdersController.cs
+++ b/OrderService/OrderService/Controllers/OrdersController.cs
@@ -36,6 +36,14 @@ namespace OrderService.Controllers
         public async Task<ActionResult<List<OrderDto>>> GetAll()
             => Ok(await _m.Send(new GetOrdersQuery()));
 
+        [HttpGet("/my")]
+        public async Task<ActionResult<List<OrderDto>>> GetMyOrders()
+        {
+            var userId = Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
+            var orders = await _m.Send(new GetOrdersByUserIdQuery(userId));
+            return Ok(orders);
+        }
+
         [HttpPut("/status/{id:guid}")]
         [Authorize(Roles = "Admin")]
         public async Task<IActionResult> UpdateStatus(Guid id, [FromBody] string status)


### PR DESCRIPTION
## Summary
- support fetching orders by userId in OrderService
- implement repository and MediatR query/handler
- expose `/my` endpoint in `OrdersController`

## Testing
- `dotnet build OrderService/OrderService.csproj -c Release` *(fails: unable to restore packages)*

------
https://chatgpt.com/codex/tasks/task_e_6851c6fecdf08333849d4e31c4ff0123