### PR TITLE
Document endpoints and add Swagger descriptions

### DIFF
--- a/CartService/CartService.API/CartService.API.csproj
+++ b/CartService/CartService.API/CartService.API.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.16" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CartService.Application\CartService.Application.csproj" />

--- a/CartService/CartService.API/Controllers/AdminCartController.cs
+++ b/CartService/CartService.API/Controllers/AdminCartController.cs
@@ -4,6 +4,7 @@ using CartService.Application.Queries;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace CartService.API.Controllers;
 
@@ -15,14 +16,17 @@ public class AdminCartController(IMediator mediator) : ControllerBase
     private readonly IMediator _mediator = mediator;
 
     [HttpGet("")]
+    [SwaggerOperation(Summary = "Get all carts", Description = "Access: Admin only")]
     public async Task<ActionResult<List<CartDto>>> GetAll()
         => Ok(await _mediator.Send(new GetAllCartsQuery()));
 
     [HttpGet("{userId}")]
+    [SwaggerOperation(Summary = "Get cart by user id", Description = "Access: Admin only")]
     public async Task<ActionResult<CartDto?>> Get(Guid userId)
         => Ok(await _mediator.Send(new GetCartQuery(userId)));
 
     [HttpPost("{userId}/additem")]
+    [SwaggerOperation(Summary = "Add item to user's cart", Description = "Access: Admin only")]
     public async Task<IActionResult> AddItem(Guid userId, [FromBody] CartItemDto item)
     {
         await _mediator.Send(new AddItemCommand(userId, item));
@@ -30,6 +34,7 @@ public class AdminCartController(IMediator mediator) : ControllerBase
     }
 
     [HttpDelete("{userId}/removeitem/{productId}")]
+    [SwaggerOperation(Summary = "Remove item from user's cart", Description = "Access: Admin only")]
     public async Task<IActionResult> RemoveItem(Guid userId, Guid productId)
     {
         await _mediator.Send(new RemoveItemCommand(userId, productId));
@@ -37,6 +42,7 @@ public class AdminCartController(IMediator mediator) : ControllerBase
     }
 
     [HttpDelete("{userId}")]
+    [SwaggerOperation(Summary = "Clear user's cart", Description = "Access: Admin only")]
     public async Task<IActionResult> Clear(Guid userId)
     {
         await _mediator.Send(new ClearCartCommand(userId));

--- a/CartService/CartService.API/Controllers/CartController.cs
+++ b/CartService/CartService.API/Controllers/CartController.cs
@@ -6,6 +6,7 @@ using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Security.Claims;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace CartService.API.Controllers;
 
@@ -20,9 +21,11 @@ public class CartController(IMediator mediator) : ControllerBase
 
     [HttpGet]
     [AllowAnonymous]
+    [SwaggerOperation(Summary = "Health check", Description = "Access: Public")]
     public IActionResult Get() => Ok("CartService is healthy.");
 
     [HttpGet("cached")]
+    [SwaggerOperation(Summary = "Show cached products", Description = "Access: User & Admin")]
     public IActionResult GetCachedProducts([FromServices] IProductCache cache)
     {
         var cachedItems = cache;
@@ -30,10 +33,12 @@ public class CartController(IMediator mediator) : ControllerBase
     }
 
     [HttpGet("mycart")]
+    [SwaggerOperation(Summary = "Get current user's cart", Description = "Access: User & Admin")]
     public async Task<ActionResult<CartDto?>> GetMyCart()
         => Ok(await _mediator.Send(new GetCartQuery(CurrentUserId())));
 
     [HttpPost("item")]
+    [SwaggerOperation(Summary = "Add item to cart", Description = "Access: User & Admin")]
     public async Task<IActionResult> AddItem([FromBody] CartItemDto item)
     {
         await _mediator.Send(new AddItemCommand(CurrentUserId(), item));
@@ -41,6 +46,7 @@ public class CartController(IMediator mediator) : ControllerBase
     }
 
     [HttpDelete("item/{productId}")]
+    [SwaggerOperation(Summary = "Remove item from cart", Description = "Access: User & Admin")]
     public async Task<IActionResult> RemoveItem(Guid productId)
     {
         await _mediator.Send(new RemoveItemCommand(CurrentUserId(), productId));
@@ -48,6 +54,7 @@ public class CartController(IMediator mediator) : ControllerBase
     }
 
     [HttpDelete("mycart")]
+    [SwaggerOperation(Summary = "Clear current cart", Description = "Access: User & Admin")]
     public async Task<IActionResult> Clear()
     {
         await _mediator.Send(new ClearCartCommand(CurrentUserId()));
@@ -55,6 +62,7 @@ public class CartController(IMediator mediator) : ControllerBase
     }
 
     [HttpPost("checkout")]
+    [SwaggerOperation(Summary = "Checkout cart", Description = "Access: User & Admin")]
     public async Task<IActionResult> Checkout()
     {
         await _mediator.Send(new CheckoutCartCommand(CurrentUserId()));

--- a/CartService/CartService.API/Program.cs
+++ b/CartService/CartService.API/Program.cs
@@ -21,6 +21,7 @@ namespace CartService.API
             builder.Services.AddEndpointsApiExplorer();
             builder.Services.AddSwaggerGen(options =>
             {
+                options.EnableAnnotations();
                 options.SwaggerDoc("v1", new OpenApiInfo { Title = "CartService", Version = "v1" });
                 options.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
                 {

--- a/CatalogService/CatalogService.API/CatalogService.API.csproj
+++ b/CatalogService/CatalogService.API/CatalogService.API.csproj
@@ -17,6 +17,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.6" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CatalogService/CatalogService.API/Controllers/CategoriesController.cs
+++ b/CatalogService/CatalogService.API/Controllers/CategoriesController.cs
@@ -4,6 +4,7 @@ using CatalogService.Application.DTOs;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
 
 [Route("[controller]")]
 [ApiController]
@@ -13,11 +14,13 @@ public class CategoriesController : ControllerBase
     public CategoriesController(IMediator mediator) => _mediator = mediator;
 
     [HttpGet]
+    [SwaggerOperation(Summary = "List all categories", Description = "Access: Public")]
     public async Task<ActionResult<List<CategoryDto>>> Get() =>
         Ok(await _mediator.Send(new GetAllCategoriesQuery()));
 
     [HttpPost]
     [Authorize(Roles = "Admin")]
+    [SwaggerOperation(Summary = "Create a new category", Description = "Access: Admin only")]
     public async Task<ActionResult<CategoryDto>> Post([FromBody] CreateCategoryCommand command) =>
         Ok(await _mediator.Send(command));
 }

--- a/CatalogService/CatalogService.API/Controllers/HealthController.cs
+++ b/CatalogService/CatalogService.API/Controllers/HealthController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace CatalogService.API.Controllers;
 
@@ -7,5 +8,6 @@ namespace CatalogService.API.Controllers;
 public class HealthController : ControllerBase
 {
     [HttpGet]
+    [SwaggerOperation(Summary = "Health check", Description = "Access: Public")]
     public IActionResult Get() => Ok("CatalogService is healthy.");
 }

--- a/CatalogService/CatalogService.API/Controllers/ProductsController.cs
+++ b/CatalogService/CatalogService.API/Controllers/ProductsController.cs
@@ -4,6 +4,7 @@ using CatalogService.Application.Products.Queries;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace CatalogService.API.Controllers
 {
@@ -15,20 +16,24 @@ namespace CatalogService.API.Controllers
         public ProductsController(IMediator mediator) => _mediator = mediator;
 
         [HttpGet]
+        [SwaggerOperation(Summary = "List all products", Description = "Access: Public")]
         public async Task<ActionResult<List<ProductDto>>> Get() =>
             Ok(await _mediator.Send(new GetAllProductsQuery()));
 
         [HttpGet("{id}")]
+        [SwaggerOperation(Summary = "Get product by id", Description = "Access: Public")]
         public async Task<ActionResult<ProductDto>> Get(Guid id) =>
             Ok(await _mediator.Send(new GetProductByIdQuery(id)));
 
         [HttpPost]
         [Authorize(Roles = "Admin")]
+        [SwaggerOperation(Summary = "Create a product", Description = "Access: Admin only")]
         public async Task<ActionResult<ProductDto>> Post([FromBody] CreateProductCommand command) =>
             Ok(await _mediator.Send(command));
 
         [HttpPut("{id}")]
         [Authorize(Roles = "Admin")]
+        [SwaggerOperation(Summary = "Update a product", Description = "Access: Admin only")]
         public async Task<ActionResult<ProductDto>> Put(Guid id, [FromBody] UpdateProductCommand command)
         {
             if (id != command.Id) return BadRequest("Id mismatch");
@@ -37,6 +42,7 @@ namespace CatalogService.API.Controllers
 
         [HttpDelete("{id}")]
         [Authorize(Roles = "Admin")]
+        [SwaggerOperation(Summary = "Delete a product", Description = "Access: Admin only")]
         public async Task<IActionResult> Delete(Guid id)
         {
             var result = await _mediator.Send(new DeleteProductCommand(id));

--- a/CatalogService/CatalogService.API/Program.cs
+++ b/CatalogService/CatalogService.API/Program.cs
@@ -29,6 +29,7 @@ namespace CatalogService.API
             builder.Services.AddEndpointsApiExplorer();
             builder.Services.AddSwaggerGen(options =>
             {
+                options.EnableAnnotations();
                 options.SwaggerDoc("v1", new OpenApiInfo
                 {
                     Title = "CatalogService",

--- a/OrderService/OrderService/Controllers/OrdersController.cs
+++ b/OrderService/OrderService/Controllers/OrdersController.cs
@@ -5,6 +5,7 @@ using System.Security.Claims;
 using OrderService.Application.DTO;
 using OrderService.Application.Commands;
 using OrderService.Application.Queries;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace OrderService.Controllers
 {
@@ -17,10 +18,12 @@ namespace OrderService.Controllers
 
         [HttpGet]
         [AllowAnonymous]
+        [SwaggerOperation(Summary = "Health check", Description = "Access: Public")]
         public Task<ActionResult<Guid>> HealthCheck()
             => Task.FromResult<ActionResult<Guid>>(Ok("OrderService is listening..."));
 
         [HttpGet("/get/{id:guid}")]
+        [SwaggerOperation(Summary = "Get order by id", Description = "Access: User & Admin (if owner or admin)")]
         public async Task<ActionResult<OrderDto?>> Get(Guid id)
         {
             var userId = Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
@@ -33,10 +36,12 @@ namespace OrderService.Controllers
 
         [HttpGet("/get")]
         [Authorize(Roles = "Admin")]
+        [SwaggerOperation(Summary = "Get all orders", Description = "Access: Admin only")]
         public async Task<ActionResult<List<OrderDto>>> GetAll()
             => Ok(await _m.Send(new GetOrdersQuery()));
 
         [HttpGet("/my")]
+        [SwaggerOperation(Summary = "Get current user's orders", Description = "Access: User & Admin")]
         public async Task<ActionResult<List<OrderDto>>> GetMyOrders()
         {
             var userId = Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
@@ -46,6 +51,7 @@ namespace OrderService.Controllers
 
         [HttpPut("/status/{id:guid}")]
         [Authorize(Roles = "Admin")]
+        [SwaggerOperation(Summary = "Update order status", Description = "Access: Admin only")]
         public async Task<IActionResult> UpdateStatus(Guid id, [FromBody] string status)
         {
             await _m.Send(new UpdateOrderStatusCommand(id, status));
@@ -54,6 +60,7 @@ namespace OrderService.Controllers
 
         [HttpDelete("/delete/{id:guid}")]
         [Authorize(Roles = "Admin")]
+        [SwaggerOperation(Summary = "Delete order", Description = "Access: Admin only")]
         public async Task<IActionResult> Delete(Guid id)
         {
             await _m.Send(new DeleteOrderCommand(id));

--- a/OrderService/OrderService/OrderService.csproj
+++ b/OrderService/OrderService/OrderService.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.6" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.16" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OrderService/OrderService/Program.cs
+++ b/OrderService/OrderService/Program.cs
@@ -34,6 +34,7 @@ namespace OrderService
             builder.Services.AddEndpointsApiExplorer();
             builder.Services.AddSwaggerGen(options =>
             {
+                options.EnableAnnotations();
                 options.SwaggerDoc("v1", new OpenApiInfo { Title = "OrderService", Version = "v1" });
                 options.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
                 {

--- a/README.md
+++ b/README.md
@@ -19,3 +19,73 @@ Kafka will be available at `kafka:9092` for the services.
 
 CatalogService publishes a `ProductCacheEvent` with a list of all products whenever the application starts or when products are created, updated or deleted. CartService listens to this topic and keeps an in-memory cache which is used to validate product IDs before items can be added to a cart.
 
+## API Endpoints
+
+Below is a short description of the available endpoints in each service and how they are secured.
+
+### CatalogService
+
+#### Admin only
+- `POST /Categories` - Create a category
+- `POST /Products` - Create a product
+- `PUT /Products/{id}` - Update a product
+- `DELETE /Products/{id}` - Delete a product
+
+#### Admin and user
+- _None_
+
+#### Unauthorized
+- `GET /Categories` - List all categories
+- `GET /Products` - List all products
+- `GET /Products/{id}` - Get product by id
+- `GET /` - Health check
+
+### CartService
+
+#### Admin only
+- `GET /admin` - Get all carts
+- `GET /admin/{userId}` - Get cart by user id
+- `POST /admin/{userId}/additem` - Add item to user's cart
+- `DELETE /admin/{userId}/removeitem/{productId}` - Remove item from user's cart
+- `DELETE /admin/{userId}` - Clear user's cart
+
+#### Admin and user
+- `GET /cached` - Show cached products
+- `GET /mycart` - Get current user's cart
+- `POST /item` - Add item to cart
+- `DELETE /item/{productId}` - Remove item from cart
+- `DELETE /mycart` - Clear current cart
+- `POST /checkout` - Checkout cart
+
+#### Unauthorized
+- `GET /` - Health check
+
+### OrderService
+
+#### Admin only
+- `GET /get` - Get all orders
+- `PUT /status/{id}` - Update order status
+- `DELETE /delete/{id}` - Delete order
+
+#### Admin and user
+- `GET /get/{id}` - Get order by id (only if owner or admin)
+- `GET /my` - Get current user's orders
+
+#### Unauthorized
+- `GET /` - Health check
+
+### UserService
+
+#### Admin only
+- `GET /admin-test` - Example endpoint for admins
+- `GET /{id}` - Get user by id
+- `GET /all` - List all users
+
+#### Admin and user
+- `GET /me` - Get current user's details
+
+#### Unauthorized
+- `GET /` - Health check
+- `POST /register` - Register a new user
+- `POST /login` - Log in and obtain JWT
+

--- a/UserService/UserService.API/Controllers/UsersController.cs
+++ b/UserService/UserService.API/Controllers/UsersController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using UserService.Application.Users.Commands;
 using UserService.Application.Users.Queries;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace UserService.API.Controllers;
 
@@ -18,10 +19,12 @@ public class UsersController : ControllerBase
     }
 
     [HttpGet]
+    [SwaggerOperation(Summary = "Health check", Description = "Access: Public")]
     public Task<ActionResult<Guid>> HealthCheck()
     => Task.FromResult<ActionResult<Guid>>(Ok("UserService is listening..."));
 
     [HttpPost("register")]
+    [SwaggerOperation(Summary = "Register a new user", Description = "Access: Public")]
     public async Task<IActionResult> Register([FromBody] RegisterUserCommand command)
     {
         var userId = await _mediator.Send(command);
@@ -29,6 +32,7 @@ public class UsersController : ControllerBase
     }
 
     [HttpPost("login")]
+    [SwaggerOperation(Summary = "Log in and obtain JWT", Description = "Access: Public")]
     public async Task<IActionResult> Login([FromBody] LoginUserCommand command)
     {
         var token = await _mediator.Send(command);
@@ -38,6 +42,7 @@ public class UsersController : ControllerBase
     [HttpGet("admin-test")]
     [Authorize(Roles = "Admin")]
     [ProducesResponseType(typeof(string), 200)]
+    [SwaggerOperation(Summary = "Example endpoint for admins", Description = "Access: Admin only")]
     public IActionResult OnlyForAdmins()
     {
         return Ok(new
@@ -49,6 +54,7 @@ public class UsersController : ControllerBase
 
     [HttpGet("me")]
     [Authorize]
+    [SwaggerOperation(Summary = "Get current user's details", Description = "Access: User & Admin")]
     public async Task<IActionResult> Me()
     {
         var dto = await _mediator.Send(new GetCurrentUserQuery(User));
@@ -57,6 +63,7 @@ public class UsersController : ControllerBase
 
     [HttpGet("{id:guid}")]
     [Authorize(Roles = "Admin")]
+    [SwaggerOperation(Summary = "Get user by id", Description = "Access: Admin only")]
     public async Task<IActionResult> GetById(Guid id)
     {
         var dto = await _mediator.Send(new GetUserByIdQuery(id));
@@ -65,6 +72,7 @@ public class UsersController : ControllerBase
 
     [HttpGet("all")]
     [Authorize(Roles = "Admin")]
+    [SwaggerOperation(Summary = "List all users", Description = "Access: Admin only")]
     public async Task<IActionResult> GetAll()
     {
         var list = await _mediator.Send(new GetAllUsersQuery());

--- a/UserService/UserService.API/Program.cs
+++ b/UserService/UserService.API/Program.cs
@@ -26,6 +26,7 @@ namespace UserService.API
             builder.Services.AddEndpointsApiExplorer();
             builder.Services.AddSwaggerGen(options =>
             {
+                options.EnableAnnotations();
                 options.SwaggerDoc("v1", new OpenApiInfo
                 {
                     Title = "UserService",

--- a/UserService/UserService.API/UserService.API.csproj
+++ b/UserService/UserService.API/UserService.API.csproj
@@ -17,6 +17,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.6" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.4.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- categorize each microservice's endpoints by access level in README
- enable Swashbuckle annotations in all API projects
- annotate controllers with `SwaggerOperation` so Swagger UI shows summaries and access rules

## Testing
- `dotnet test UserService/UserService.Tests/UserService.UnitTests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6851d7c0a68083338f8bd775ceccdd6c