### PR TITLE
Add NotificationService for email notifications

### DIFF
--- a/NotificationService/Controllers/HealthController.cs
+++ b/NotificationService/Controllers/HealthController.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace NotificationService.Controllers;
+
+[Route("")]
+[ApiController]
+public class HealthController : ControllerBase
+{
+    [HttpGet]
+    [SwaggerOperation(Summary = "Health check", Description = "Access: Public")]
+    public IActionResult Get() => Ok("NotificationService is healthy.");
+}

--- a/NotificationService/Dockerfile
+++ b/NotificationService/Dockerfile
@@ -1,0 +1,21 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 8080
+EXPOSE 8081
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+ARG BUILD_CONFIGURATION=Release
+WORKDIR /src
+
+# Copy the full NotificationService folder
+COPY . .
+
+WORKDIR /src/NotificationService
+RUN dotnet restore
+RUN dotnet publish -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "NotificationService.dll"]
+

--- a/NotificationService/Messaging/EmailMessage.cs
+++ b/NotificationService/Messaging/EmailMessage.cs
@@ -1,0 +1,3 @@
+namespace NotificationService.Messaging;
+
+public record EmailMessage(string To, string Subject, string Body);

--- a/NotificationService/Messaging/PasswordResetConsumer.cs
+++ b/NotificationService/Messaging/PasswordResetConsumer.cs
@@ -1,0 +1,72 @@
+using Confluent.Kafka;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using NotificationService.Services;
+using System.Text.Json;
+
+namespace NotificationService.Messaging;
+
+public class PasswordResetConsumer : BackgroundService
+{
+    private IConsumer<Ignore, string>? _consumer;
+    private readonly string _topic;
+    private readonly IConfiguration _configuration;
+    private readonly IEmailSender _emailSender;
+    private readonly ILogger<PasswordResetConsumer> _logger;
+
+    public PasswordResetConsumer(IConfiguration configuration, IEmailSender emailSender, ILogger<PasswordResetConsumer> logger)
+    {
+        _configuration = configuration;
+        _emailSender = emailSender;
+        _logger = logger;
+        _topic = configuration["Kafka:PasswordResetTopic"] ?? "password-reset";
+    }
+
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var config = new ConsumerConfig
+        {
+            GroupId = "notificationservice",
+            BootstrapServers = _configuration["Kafka:BootstrapServers"] ?? "kafka:9092",
+            AutoOffsetReset = AutoOffsetReset.Earliest,
+            EnableAutoCommit = true
+        };
+
+        _ = Task.Run(async () =>
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    _logger.LogInformation("Connecting to Kafka {Broker}...", config.BootstrapServers);
+                    _consumer = new ConsumerBuilder<Ignore, string>(config).Build();
+                    _consumer.Subscribe(_topic);
+                    _logger.LogInformation("Subscribed to topic '{Topic}'", _topic);
+
+                    while (!stoppingToken.IsCancellationRequested)
+                    {
+                        var result = _consumer.Consume(stoppingToken);
+                        var message = JsonSerializer.Deserialize<EmailMessage>(result.Message.Value);
+                        if (message != null)
+                        {
+                            await _emailSender.SendEmailAsync(message.To, message.Subject, message.Body);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Kafka consumer error. Retrying in 5s...");
+                    await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+                }
+                finally
+                {
+                    _consumer?.Close();
+                    _consumer?.Dispose();
+                }
+            }
+        }, stoppingToken);
+
+        return Task.CompletedTask;
+    }
+}

--- a/NotificationService/Messaging/PaymentReceiptConsumer.cs
+++ b/NotificationService/Messaging/PaymentReceiptConsumer.cs
@@ -1,0 +1,72 @@
+using Confluent.Kafka;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using NotificationService.Services;
+using System.Text.Json;
+
+namespace NotificationService.Messaging;
+
+public class PaymentReceiptConsumer : BackgroundService
+{
+    private IConsumer<Ignore, string>? _consumer;
+    private readonly string _topic;
+    private readonly IConfiguration _configuration;
+    private readonly IEmailSender _emailSender;
+    private readonly ILogger<PaymentReceiptConsumer> _logger;
+
+    public PaymentReceiptConsumer(IConfiguration configuration, IEmailSender emailSender, ILogger<PaymentReceiptConsumer> logger)
+    {
+        _configuration = configuration;
+        _emailSender = emailSender;
+        _logger = logger;
+        _topic = configuration["Kafka:PaymentReceiptTopic"] ?? "payment-receipt";
+    }
+
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var config = new ConsumerConfig
+        {
+            GroupId = "notificationservice",
+            BootstrapServers = _configuration["Kafka:BootstrapServers"] ?? "kafka:9092",
+            AutoOffsetReset = AutoOffsetReset.Earliest,
+            EnableAutoCommit = true
+        };
+
+        _ = Task.Run(async () =>
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    _logger.LogInformation("Connecting to Kafka {Broker}...", config.BootstrapServers);
+                    _consumer = new ConsumerBuilder<Ignore, string>(config).Build();
+                    _consumer.Subscribe(_topic);
+                    _logger.LogInformation("Subscribed to topic '{Topic}'", _topic);
+
+                    while (!stoppingToken.IsCancellationRequested)
+                    {
+                        var result = _consumer.Consume(stoppingToken);
+                        var message = JsonSerializer.Deserialize<EmailMessage>(result.Message.Value);
+                        if (message != null)
+                        {
+                            await _emailSender.SendEmailAsync(message.To, message.Subject, message.Body);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Kafka consumer error. Retrying in 5s...");
+                    await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+                }
+                finally
+                {
+                    _consumer?.Close();
+                    _consumer?.Dispose();
+                }
+            }
+        }, stoppingToken);
+
+        return Task.CompletedTask;
+    }
+}

--- a/NotificationService/Messaging/UserRegisteredConsumer.cs
+++ b/NotificationService/Messaging/UserRegisteredConsumer.cs
@@ -1,0 +1,72 @@
+using Confluent.Kafka;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using NotificationService.Services;
+using System.Text.Json;
+
+namespace NotificationService.Messaging;
+
+public class UserRegisteredConsumer : BackgroundService
+{
+    private IConsumer<Ignore, string>? _consumer;
+    private readonly string _topic;
+    private readonly IConfiguration _configuration;
+    private readonly IEmailSender _emailSender;
+    private readonly ILogger<UserRegisteredConsumer> _logger;
+
+    public UserRegisteredConsumer(IConfiguration configuration, IEmailSender emailSender, ILogger<UserRegisteredConsumer> logger)
+    {
+        _configuration = configuration;
+        _emailSender = emailSender;
+        _logger = logger;
+        _topic = configuration["Kafka:UserRegisteredTopic"] ?? "user-registered";
+    }
+
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var config = new ConsumerConfig
+        {
+            GroupId = "notificationservice",
+            BootstrapServers = _configuration["Kafka:BootstrapServers"] ?? "kafka:9092",
+            AutoOffsetReset = AutoOffsetReset.Earliest,
+            EnableAutoCommit = true
+        };
+
+        _ = Task.Run(async () =>
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    _logger.LogInformation("Connecting to Kafka {Broker}...", config.BootstrapServers);
+                    _consumer = new ConsumerBuilder<Ignore, string>(config).Build();
+                    _consumer.Subscribe(_topic);
+                    _logger.LogInformation("Subscribed to topic '{Topic}'", _topic);
+
+                    while (!stoppingToken.IsCancellationRequested)
+                    {
+                        var result = _consumer.Consume(stoppingToken);
+                        var message = JsonSerializer.Deserialize<EmailMessage>(result.Message.Value);
+                        if (message != null)
+                        {
+                            await _emailSender.SendEmailAsync(message.To, message.Subject, message.Body);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Kafka consumer error. Retrying in 5s...");
+                    await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+                }
+                finally
+                {
+                    _consumer?.Close();
+                    _consumer?.Dispose();
+                }
+            }
+        }, stoppingToken);
+
+        return Task.CompletedTask;
+    }
+}

--- a/NotificationService/NotificationService.csproj
+++ b/NotificationService/NotificationService.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Confluent.Kafka" Version="2.10.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.6" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.4.0" />
+  </ItemGroup>
+</Project>

--- a/NotificationService/Program.cs
+++ b/NotificationService/Program.cs
@@ -1,0 +1,27 @@
+using NotificationService.Services;
+using NotificationService.Messaging;
+using Microsoft.OpenApi.Models;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(options =>
+{
+    options.EnableAnnotations();
+    options.SwaggerDoc("v1", new OpenApiInfo { Title = "NotificationService", Version = "v1" });
+});
+
+builder.Services.AddSingleton<IEmailSender, SmtpEmailSender>();
+builder.Services.AddHostedService<UserRegisteredConsumer>();
+builder.Services.AddHostedService<PasswordResetConsumer>();
+builder.Services.AddHostedService<PaymentReceiptConsumer>();
+
+var app = builder.Build();
+
+app.UseSwagger();
+app.UseSwaggerUI();
+
+app.MapControllers();
+
+await app.RunAsync();

--- a/NotificationService/Properties/launchSettings.json
+++ b/NotificationService/Properties/launchSettings.json
@@ -1,0 +1,38 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:52902",
+      "sslPort": 44357
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5177",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7262;http://localhost:5177",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/NotificationService/Services/IEmailSender.cs
+++ b/NotificationService/Services/IEmailSender.cs
@@ -1,0 +1,6 @@
+namespace NotificationService.Services;
+
+public interface IEmailSender
+{
+    Task SendEmailAsync(string to, string subject, string body);
+}

--- a/NotificationService/Services/SmtpEmailSender.cs
+++ b/NotificationService/Services/SmtpEmailSender.cs
@@ -1,0 +1,49 @@
+using System.Net;
+using System.Net.Mail;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace NotificationService.Services;
+
+public class SmtpEmailSender : IEmailSender
+{
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<SmtpEmailSender> _logger;
+
+    public SmtpEmailSender(IConfiguration configuration, ILogger<SmtpEmailSender> logger)
+    {
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    public async Task SendEmailAsync(string to, string subject, string body)
+    {
+        var host = _configuration["Smtp:Host"] ?? "localhost";
+        var portStr = _configuration["Smtp:Port"] ?? "25";
+        var user = _configuration["Smtp:User"];
+        var pass = _configuration["Smtp:Pass"];
+        var from = _configuration["Smtp:From"] ?? user ?? "noreply@example.com";
+        int.TryParse(portStr, out var port);
+        using var client = new SmtpClient(host, port)
+        {
+            EnableSsl = false
+        };
+        if (!string.IsNullOrEmpty(user))
+        {
+            client.Credentials = new NetworkCredential(user, pass);
+        }
+        var message = new MailMessage(from, to, subject, body)
+        {
+            IsBodyHtml = true
+        };
+        try
+        {
+            await client.SendMailAsync(message);
+            _logger.LogInformation("Email sent to {To}", to);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to send email to {To}", to);
+        }
+    }
+}

--- a/NotificationService/appsettings.Development.json
+++ b/NotificationService/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/NotificationService/appsettings.json
+++ b/NotificationService/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/TeaShopService.sln
+++ b/TeaShopService.sln
@@ -53,6 +53,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CartService.Infrastructure"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CartService.API", "CartService\CartService.API\CartService.API.csproj", "{A5635F5E-E5C5-4B88-9912-804476C48831}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NotificationService", "NotificationService\NotificationService.csproj", "{420A0E33-5336-44AA-8FEC-77BC46EA2151}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -139,6 +141,10 @@ Global
 		{A5635F5E-E5C5-4B88-9912-804476C48831}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A5635F5E-E5C5-4B88-9912-804476C48831}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A5635F5E-E5C5-4B88-9912-804476C48831}.Release|Any CPU.Build.0 = Release|Any CPU
+		{420A0E33-5336-44AA-8FEC-77BC46EA2151}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{420A0E33-5336-44AA-8FEC-77BC46EA2151}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{420A0E33-5336-44AA-8FEC-77BC46EA2151}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{420A0E33-5336-44AA-8FEC-77BC46EA2151}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,24 @@ services:
       - kafka
       - catalogservice
     volumes: []
+  notificationservice:
+    build:
+      context: ./NotificationService
+      dockerfile: NotificationService/Dockerfile
+    environment:
+      Kafka__BootstrapServers: "${KAFKA_BOOTSTRAP_SERVERS}"
+      Kafka__UserRegisteredTopic: "${KAFKA_USER_REGISTERED_TOPIC}"
+      Kafka__PasswordResetTopic: "${KAFKA_PASSWORD_RESET_TOPIC}"
+      Kafka__PaymentReceiptTopic: "${KAFKA_PAYMENT_RECEIPT_TOPIC}"
+      Smtp__Host: "${SMTP_HOST}"
+      Smtp__Port: "${SMTP_PORT}"
+      Smtp__User: "${SMTP_USER}"
+      Smtp__Pass: "${SMTP_PASS}"
+      Smtp__From: "${SMTP_FROM}"
+    expose:
+      - "8080"
+    depends_on:
+      - kafka
   apigateway:
     build:
       context: .


### PR DESCRIPTION
## Summary
- add NotificationService project with SMTP email sender
- implement Kafka consumers for user registration, password reset and payment receipt
- create Dockerfile and wire up service in docker-compose

## Testing
- `dotnet build TeaShopService.sln -c Release`
- `dotnet test TeaShopService.sln`

------
https://chatgpt.com/codex/tasks/task_e_6851f44f5df88333a89670dd289654ee