### PR TITLE
Handle missing user when requesting password reset

### DIFF
--- a/UserService/UserService.API/Controllers/UsersController.cs
+++ b/UserService/UserService.API/Controllers/UsersController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using UserService.Application.Users.Commands;
 using UserService.Application.Users.Queries;
+using UserService.Domain.Exceptions;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace UserService.API.Controllers;
@@ -43,8 +44,15 @@ public class UsersController : ControllerBase
     [SwaggerOperation(Summary = "Request password reset", Description = "Access: Public")]
     public async Task<IActionResult> RequestPasswordReset([FromBody] RequestPasswordResetCommand command)
     {
-        await _mediator.Send(command);
-        return Ok();
+        try
+        {
+            await _mediator.Send(command);
+            return Ok();
+        }
+        catch (UserNotFoundException)
+        {
+            return NotFound();
+        }
     }
 
     [HttpPost("reset-password")]

--- a/UserService/UserService.Application/Users/Commands/RequestPasswordResetCommandHandler.cs
+++ b/UserService/UserService.Application/Users/Commands/RequestPasswordResetCommandHandler.cs
@@ -3,6 +3,7 @@ using System;
 using UserService.Application.DTOs;
 using UserService.Application.Interfaces;
 using UserService.Domain.Interfaces;
+using UserService.Domain.Exceptions;
 
 namespace UserService.Application.Users.Commands;
 
@@ -22,7 +23,7 @@ public class RequestPasswordResetCommandHandler : IRequestHandler<RequestPasswor
     public async Task Handle(RequestPasswordResetCommand request, CancellationToken cancellationToken)
     {
         var user = await _repo.GetByEmailAsync(request.Email)
-            ?? throw new Exception("User not found");
+            ?? throw new UserNotFoundException(request.Email);
 
         var token = Guid.NewGuid().ToString();
         _tokens.Store(user.Id, token);

--- a/UserService/UserService.Application/Users/Commands/ResetPasswordCommandHandler.cs
+++ b/UserService/UserService.Application/Users/Commands/ResetPasswordCommandHandler.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Identity;
 using UserService.Application.Interfaces;
 using UserService.Domain.Entities;
 using UserService.Domain.Interfaces;
+using UserService.Domain.Exceptions;
 
 namespace UserService.Application.Users.Commands;
 
@@ -23,7 +24,7 @@ public class ResetPasswordCommandHandler : IRequestHandler<ResetPasswordCommand>
     {
         var userId = _tokens.Take(request.Token) ?? throw new Exception("Invalid token");
 
-        var user = await _repo.GetByIdAsync(userId) ?? throw new Exception("User not found");
+        var user = await _repo.GetByIdAsync(userId) ?? throw new UserNotFoundException(userId.ToString());
 
         user.PasswordHash = _hasher.HashPassword(user, request.NewPassword);
 

--- a/UserService/UserService.Domain/Exceptions/UserNotFoundException.cs
+++ b/UserService/UserService.Domain/Exceptions/UserNotFoundException.cs
@@ -1,0 +1,9 @@
+namespace UserService.Domain.Exceptions;
+
+public class UserNotFoundException : Exception
+{
+    public UserNotFoundException(string email)
+        : base($"User with email '{email}' was not found.")
+    {
+    }
+}


### PR DESCRIPTION
## Summary
- add `UserNotFoundException` to domain
- use the exception in password reset handlers
- return 404 when requesting password reset for a non-existent email

## Testing
- `dotnet test TeaShopService.sln` *(fails: "Specify which project or solution file to use" then blocked network events)*

------
https://chatgpt.com/codex/tasks/task_e_6852096d0d348333b088a902c5b3a87d