### PR TITLE
Fix UpdateUser request body

### DIFF
--- a/UserService/UserService.API/Controllers/UsersController.cs
+++ b/UserService/UserService.API/Controllers/UsersController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using UserService.Application.Users.Commands;
 using UserService.Application.Users.Queries;
+using UserService.Application.Users.DTOs;
 using UserService.Domain.Exceptions;
 using System.Security.Claims;
 using Swashbuckle.AspNetCore.Annotations;
@@ -90,13 +91,13 @@ public class UsersController : ControllerBase
     [HttpPut("update")]
     [Authorize]
     [SwaggerOperation(Summary = "Update current user", Description = "Access: User & Admin")]
-    public async Task<IActionResult> Update([FromBody] UpdateUserCommand command)
+    public async Task<IActionResult> Update([FromBody] UpdateUserDto dto)
     {
         var idClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
         if (idClaim is null)
             return Unauthorized();
 
-        var cmd = new UpdateUserCommand(Guid.Parse(idClaim), command.Email, command.Username);
+        var cmd = new UpdateUserCommand(Guid.Parse(idClaim), dto.Email, dto.Username);
         await _mediator.Send(cmd);
         return Ok();
     }

--- a/UserService/UserService.Application/DTOs/UpdateUserDto.cs
+++ b/UserService/UserService.Application/DTOs/UpdateUserDto.cs
@@ -1,0 +1,7 @@
+namespace UserService.Application.Users.DTOs;
+
+public class UpdateUserDto
+{
+    public string? Email { get; set; }
+    public string? Username { get; set; }
+}


### PR DESCRIPTION
## Summary
- add `UpdateUserDto` without Id field
- update UsersController to use new DTO so Swagger no longer expects Id in body

## Testing
- `dotnet build UserService/UserService.API/UserService.API.csproj -c Release`
- `dotnet test CatalogService/CatalogService.UnitTests/CatalogService.UnitTests.csproj`
- `dotnet test CatalogService/CatalogService.IntegrationTests/CatalogService.IntegrationTests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6855ed9261c883339c9f65fa9fa36778