### PR TITLE
Add OrderStatus enum and consumer

### DIFF
--- a/OrderService/OrderService.Application/Commands/UpdateOrderStatusCommand.cs
+++ b/OrderService/OrderService.Application/Commands/UpdateOrderStatusCommand.cs
@@ -1,7 +1,8 @@
 ﻿using MediatR;
+using OrderService.Domain.Enums;
 using System;
 
 namespace OrderService.Application.Commands
 {
-    public sealed record UpdateOrderStatusCommand(Guid OrderId, string NewStatus) : IRequest;
+    public sealed record UpdateOrderStatusCommand(Guid OrderId, OrderStatus NewStatus) : IRequest;
 }

--- a/OrderService/OrderService.Application/DTO/OrderDto.cs
+++ b/OrderService/OrderService.Application/DTO/OrderDto.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using OrderService.Domain.Enums;
 
 namespace OrderService.Application.DTO
 {
@@ -8,7 +9,7 @@ namespace OrderService.Application.DTO
         public Guid Id { get; init; } = Guid.NewGuid();
         public Guid UserId { get; init; }
         public DateTime OrderDate { get; init; }
-        public string Status { get; init; } = default!;
+        public OrderStatus Status { get; init; }
         public List<OrderItemDto> Items { get; init; } = [];
         public string DeliveryLocation { get; init; } = string.Empty;
         public string PaymentMethod { get; init; } = string.Empty;

--- a/OrderService/OrderService.Application/DTO/OrderPaidEvent.cs
+++ b/OrderService/OrderService.Application/DTO/OrderPaidEvent.cs
@@ -1,0 +1,6 @@
+namespace OrderService.Application.DTO;
+
+public class OrderPaidEvent
+{
+    public Guid OrderId { get; set; }
+}

--- a/OrderService/OrderService.Application/Services/OrderService.cs
+++ b/OrderService/OrderService.Application/Services/OrderService.cs
@@ -2,6 +2,7 @@
 using OrderService.Application.DTO;
 using OrderService.Application.Interfaces;
 using OrderService.Domain.Entities;
+using OrderService.Domain.Enums;
 using OrderService.Domain.Repositories;
 using System.Linq;
 
@@ -28,7 +29,7 @@ namespace OrderService.Application.Services
                 Id = Guid.NewGuid(),
                 UserId = dto.UserId,
                 OrderDate = DateTime.UtcNow,
-                Status = "New",
+                Status = OrderStatus.New,
                 DeliveryLocation = dto.DeliveryLocation,
                 PaymentMethod = dto.PaymentMethod,
                 OrderItems = []

--- a/OrderService/OrderService.Domain/Entities/Order.cs
+++ b/OrderService/OrderService.Domain/Entities/Order.cs
@@ -1,4 +1,6 @@
-﻿using OrderService.Domain.Entities;
+﻿using OrderService.Domain.Enums;
+
+namespace OrderService.Domain.Entities;
 
 public class Order
 {
@@ -6,7 +8,7 @@ public class Order
     public Guid UserId { get; set; }
     public DateTime OrderDate { get; set; }
     public List<OrderItem> OrderItems { get; set; } = new();
-    public string Status { get; set; } = "New";
+    public OrderStatus Status { get; set; } = OrderStatus.New;
     public string DeliveryLocation { get; set; } = string.Empty;
     public string PaymentMethod { get; set; } = string.Empty;
 }

--- a/OrderService/OrderService.Domain/Enums/OrderStatus.cs
+++ b/OrderService/OrderService.Domain/Enums/OrderStatus.cs
@@ -1,0 +1,7 @@
+namespace OrderService.Domain.Enums;
+
+public enum OrderStatus
+{
+    New,
+    Paid
+}

--- a/OrderService/OrderService.Infrastructure/Data/Migrations/20250620234709_AddOrderStatusEnum.Designer.cs
+++ b/OrderService/OrderService.Infrastructure/Data/Migrations/20250620234709_AddOrderStatusEnum.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace OrderService.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(OrdersDbContext))]
-    partial class OrdersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250620234709_AddOrderStatusEnum")]
+    partial class AddOrderStatusEnum
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/OrderService/OrderService.Infrastructure/Data/Migrations/20250620234709_AddOrderStatusEnum.cs
+++ b/OrderService/OrderService.Infrastructure/Data/Migrations/20250620234709_AddOrderStatusEnum.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OrderService.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOrderStatusEnum : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/OrderService/OrderService.Infrastructure/Data/OrdersDbContext.cs
+++ b/OrderService/OrderService.Infrastructure/Data/OrdersDbContext.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using OrderService.Domain.Entities;
+using OrderService.Domain.Enums;
 
 public class OrdersDbContext : DbContext
 {
@@ -7,4 +8,13 @@ public class OrdersDbContext : DbContext
 
     public DbSet<Order> Orders => Set<Order>();
     public DbSet<OrderItem> OrderItems => Set<OrderItem>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.Entity<Order>(entity =>
+        {
+            entity.Property(o => o.Status).HasConversion<string>();
+        });
+    }
 }

--- a/OrderService/OrderService.Infrastructure/Data/OrdersDbContextFactory.cs
+++ b/OrderService/OrderService.Infrastructure/Data/OrdersDbContextFactory.cs
@@ -1,0 +1,20 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
+
+namespace OrderService.Infrastructure.Data;
+
+public class OrdersDbContextFactory : IDesignTimeDbContextFactory<OrdersDbContext>
+{
+    public OrdersDbContext CreateDbContext(string[] args)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddJsonFile("appsettings.json")
+            .Build();
+
+        var optionsBuilder = new DbContextOptionsBuilder<OrdersDbContext>();
+        optionsBuilder.UseSqlServer(configuration.GetConnectionString("Default"));
+
+        return new OrdersDbContext(optionsBuilder.Options);
+    }
+}

--- a/OrderService/OrderService.Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/OrderService/OrderService.Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IOrderRepository, OrderRepository>();
         services.AddSingleton<IOrderCreatedProducer, KafkaOrderCreatedProducer>();
         services.AddHostedService<CartCheckoutConsumer>();
+        services.AddHostedService<OrderPaidConsumer>();
 
         return services;
     }

--- a/OrderService/OrderService.Infrastructure/Messaging/OrderPaidConsumer.cs
+++ b/OrderService/OrderService.Infrastructure/Messaging/OrderPaidConsumer.cs
@@ -1,0 +1,79 @@
+using Confluent.Kafka;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using OrderService.Application.DTO;
+using OrderService.Domain.Enums;
+using OrderService.Domain.Repositories;
+using System.Text.Json;
+
+namespace OrderService.Infrastructure.Messaging;
+
+public class OrderPaidConsumer : BackgroundService
+{
+    private IConsumer<Ignore, string>? _consumer;
+    private readonly string _topic;
+    private readonly IConfiguration _configuration;
+    private readonly IOrderRepository _repository;
+    private readonly ILogger<OrderPaidConsumer> _logger;
+
+    public OrderPaidConsumer(IConfiguration configuration, IOrderRepository repository, ILogger<OrderPaidConsumer> logger)
+    {
+        _configuration = configuration;
+        _repository = repository;
+        _logger = logger;
+        _topic = configuration["Kafka:OrderPaidTopic"] ?? "order-paid";
+    }
+
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var config = new ConsumerConfig
+        {
+            GroupId = "orderservice",
+            BootstrapServers = _configuration["Kafka:BootstrapServers"] ?? "kafka:9092",
+            AutoOffsetReset = AutoOffsetReset.Earliest,
+            EnableAutoCommit = true
+        };
+
+        _ = Task.Run(async () =>
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    _logger.LogInformation("Connecting to Kafka {Broker}...", config.BootstrapServers);
+                    _consumer = new ConsumerBuilder<Ignore, string>(config).Build();
+                    _consumer.Subscribe(_topic);
+                    _logger.LogInformation("Subscribed to topic '{Topic}'", _topic);
+
+                    while (!stoppingToken.IsCancellationRequested)
+                    {
+                        var result = _consumer.Consume(stoppingToken);
+                        var evt = JsonSerializer.Deserialize<OrderPaidEvent>(result.Message.Value);
+                        if (evt != null)
+                        {
+                            var order = await _repository.GetByIdAsync(evt.OrderId);
+                            if (order != null)
+                            {
+                                order.Status = OrderStatus.Paid;
+                                await _repository.SaveChangesAsync();
+                            }
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Kafka consumer error. Retrying in 5s...");
+                    await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+                }
+                finally
+                {
+                    _consumer?.Close();
+                    _consumer?.Dispose();
+                }
+            }
+        }, stoppingToken);
+
+        return Task.CompletedTask;
+    }
+}

--- a/OrderService/OrderService/Controllers/OrdersController.cs
+++ b/OrderService/OrderService/Controllers/OrdersController.cs
@@ -5,6 +5,7 @@ using System.Security.Claims;
 using OrderService.Application.DTO;
 using OrderService.Application.Commands;
 using OrderService.Application.Queries;
+using OrderService.Domain.Enums;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace OrderService.Controllers
@@ -52,7 +53,7 @@ namespace OrderService.Controllers
         [HttpPut("/status/{id:guid}")]
         [Authorize(Roles = "Admin")]
         [SwaggerOperation(Summary = "Update order status", Description = "Access: Admin only")]
-        public async Task<IActionResult> UpdateStatus(Guid id, [FromBody] string status)
+        public async Task<IActionResult> UpdateStatus(Guid id, [FromBody] OrderStatus status)
         {
             await _m.Send(new UpdateOrderStatusCommand(id, status));
             return NoContent();


### PR DESCRIPTION
## Summary
- introduce `OrderStatus` enum and use it in the domain
- switch DTOs, commands and services to the enum
- add `OrderPaidConsumer` listening on the `order-paid` topic
- register the new consumer
- provide EF design-time factory and new migration

## Testing
- `dotnet build OrderService/OrderService/OrderService.csproj -warnaserror`
- `dotnet test TeaShopService.sln --no-build`
- `dotnet ef migrations add AddOrderStatusEnum -p OrderService/OrderService.Infrastructure/OrderService.Infrastructure.csproj -s OrderService/OrderService/OrderService.csproj --context OrdersDbContext`
- `dotnet ef database update -p OrderService/OrderService.Infrastructure/OrderService.Infrastructure.csproj -s OrderService/OrderService/OrderService.csproj --context OrdersDbContext` *(fails: The ConnectionString property has not been initialized.)*

------
https://chatgpt.com/codex/tasks/task_e_6855f19b4dd483339f8028579a63ee94