### PR TITLE
Allow password update and improve docs

### DIFF
--- a/ApiGateway/Program.cs
+++ b/ApiGateway/Program.cs
@@ -51,16 +51,18 @@ namespace ApiGateway
                     Title = "ApiGateway",
                     Version = "v1",
                     Description = """
-                        This is the entry point for all TeaShop micro-services.
+                        Entry point for all TeaShop micro-services.
 
-                        • Select **OrderService V1** in the drop-down (top right) to browse
-                          the OrderService endpoints routed through the `/orders` prefix.
+                        • Select a cluster (e.g. **OrderService V1**) in the drop-down
+                          to view its endpoints routed through the gateway.
 
-                        • The default “Gateway” doc is intentionally empty – it only serves
-                          as a starting page.
+                        Example workflow with events:
+                        Register -> UserRegisteredEvent -> Add to cart ->
+                        Checkout -> CartCheckedOutEvent -> OrderService -> OrderCreatedEvent ->
+                        Pay -> OrderPaidEvent -> email receipt
 
-                        ⚠️  It can take a few seconds after startup for downstream service
-                           Swagger documents to become available, so changing the swagger might result in an error.
+                        ⚠️  Downstream service docs may take a few seconds after
+                           startup to appear.
                         """
                 });
             });

--- a/PaymentService/Controllers/PaymentsController.cs
+++ b/PaymentService/Controllers/PaymentsController.cs
@@ -25,11 +25,14 @@ public class PaymentsController(IOrderPaidProducer orderProducer, IEmailProducer
         var orderEvent = new OrderPaidEvent { OrderId = request.OrderId };
         await _orderProducer.PublishAsync(orderEvent);
 
-        var message = new EmailMessage(email, "Payment Receipt", $"Payment received for order {request.OrderId}.");
+        var items = request.Items is null ? string.Empty : string.Join(", ", request.Items);
+        var body = $"Payment received for order {request.OrderId} on {DateTime.UtcNow:yyyy-MM-dd}.\n" +
+                   $"Amount: {request.Amount:C}\nItems: {items}";
+        var message = new EmailMessage(email, "Payment Receipt", body);
         await _emailProducer.PublishAsync(message);
 
         return Ok();
     }
 }
 
-public record PaymentRequest(Guid OrderId);
+public record PaymentRequest(Guid OrderId, decimal Amount, string[] Items);

--- a/README.md
+++ b/README.md
@@ -119,3 +119,11 @@ Below is a short description of the available endpoints in each service and how 
 #### Unauthorized
 - `GET /WeatherForecast` - Example endpoint
 - `GET /WeatherForecast/TestOrderServiceResponse` - Proxy call to OrderService
+
+## Example Flow
+
+1. User registers -> `UserRegisteredEvent` -> welcome email
+2. User adds items to cart -> `ProductCacheEvent` keeps cache updated
+3. User checks out -> `CartCheckedOutEvent` on **cart-checked-out** -> OrderService creates the order and publishes `OrderCreatedEvent`
+4. `OrderCreatedEvent` -> CartService clears the cart
+5. Payment succeeds -> `OrderPaidEvent` -> order status updated and receipt email sent

--- a/UserService/UserService.API/Controllers/UsersController.cs
+++ b/UserService/UserService.API/Controllers/UsersController.cs
@@ -97,7 +97,7 @@ public class UsersController : ControllerBase
         if (idClaim is null)
             return Unauthorized();
 
-        var cmd = new UpdateUserCommand(Guid.Parse(idClaim), dto.Email, dto.Username);
+        var cmd = new UpdateUserCommand(Guid.Parse(idClaim), dto.Email, dto.Username, dto.Password);
         await _mediator.Send(cmd);
         return Ok();
     }

--- a/UserService/UserService.Application/DTOs/UpdateUserDto.cs
+++ b/UserService/UserService.Application/DTOs/UpdateUserDto.cs
@@ -4,4 +4,5 @@ public class UpdateUserDto
 {
     public string? Email { get; set; }
     public string? Username { get; set; }
+    public string? Password { get; set; }
 }

--- a/UserService/UserService.Application/Users/Commands/UpdateUserCommand.cs
+++ b/UserService/UserService.Application/Users/Commands/UpdateUserCommand.cs
@@ -2,4 +2,4 @@ using MediatR;
 
 namespace UserService.Application.Users.Commands;
 
-public record UpdateUserCommand(Guid Id, string? Email, string? Username) : IRequest;
+public record UpdateUserCommand(Guid Id, string? Email, string? Username, string? Password) : IRequest;

--- a/UserService/UserService.Application/Users/Commands/UpdateUserCommandHandler.cs
+++ b/UserService/UserService.Application/Users/Commands/UpdateUserCommandHandler.cs
@@ -1,5 +1,7 @@
 using MediatR;
+using Microsoft.AspNetCore.Identity;
 using UserService.Domain.Interfaces;
+using UserService.Domain.Entities;
 using UserService.Domain.Exceptions;
 
 namespace UserService.Application.Users.Commands;
@@ -7,10 +9,12 @@ namespace UserService.Application.Users.Commands;
 public class UpdateUserCommandHandler : IRequestHandler<UpdateUserCommand>
 {
     private readonly IUserRepository _repo;
+    private readonly IPasswordHasher<User> _hasher;
 
-    public UpdateUserCommandHandler(IUserRepository repo)
+    public UpdateUserCommandHandler(IUserRepository repo, IPasswordHasher<User> hasher)
     {
         _repo = repo;
+        _hasher = hasher;
     }
 
     public async Task Handle(UpdateUserCommand request, CancellationToken cancellationToken)
@@ -30,6 +34,11 @@ public class UpdateUserCommandHandler : IRequestHandler<UpdateUserCommand>
         if (!string.IsNullOrWhiteSpace(request.Username))
         {
             user.Username = request.Username;
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.Password))
+        {
+            user.PasswordHash = _hasher.HashPassword(user, request.Password);
         }
 
         await _repo.UpdateAsync(user);


### PR DESCRIPTION
## Summary
- allow users to change password through `PUT /update`
- include payment amount/date/items in receipt emails
- document basic event workflow in README
- update ApiGateway swagger description with workflow example
- clarify the checkout event flow

## Testing
- `dotnet build UserService/UserService.API/UserService.API.csproj -c Release`
- `dotnet build PaymentService/PaymentService.csproj -c Release`
- `dotnet build ApiGateway/ApiGateway.csproj -c Release`
- `dotnet test CatalogService/CatalogService.UnitTests/CatalogService.UnitTests.csproj`
- `dotnet test CatalogService/CatalogService.IntegrationTests/CatalogService.IntegrationTests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6855ffabe0b08333b76581d019baade5