### PR TITLE
Update order cache at startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@ KAFKA_PRODUCT_CACHE_TOPIC=product-cache
 KAFKA_CART_CHECKED_OUT_TOPIC=cart-checked-out
 KAFKA_ORDER_CREATED_TOPIC=order-created
 KAFKA_ORDER_PAID_TOPIC=order-paid
+KAFKA_ORDER_CACHE_TOPIC=order-cache
 
 # Notification events
 KAFKA_USER_REGISTERED_TOPIC=user-registered

--- a/OrderService/OrderService.Application/DTO/OrderCacheEvent.cs
+++ b/OrderService/OrderService.Application/DTO/OrderCacheEvent.cs
@@ -1,0 +1,6 @@
+namespace OrderService.Application.DTO;
+
+public class OrderCacheEvent
+{
+    public Dictionary<Guid, Guid> Orders { get; set; } = new();
+}

--- a/OrderService/OrderService.Application/Interfaces/IOrderCacheProducer.cs
+++ b/OrderService/OrderService.Application/Interfaces/IOrderCacheProducer.cs
@@ -1,0 +1,8 @@
+using OrderService.Application.DTO;
+
+namespace OrderService.Application.Interfaces;
+
+public interface IOrderCacheProducer
+{
+    Task PublishAsync(OrderCacheEvent cache, CancellationToken ct = default);
+}

--- a/OrderService/OrderService.Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/OrderService/OrderService.Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -18,6 +18,7 @@ public static class ServiceCollectionExtensions
 
         services.AddScoped<IOrderRepository, OrderRepository>();
         services.AddSingleton<IOrderCreatedProducer, KafkaOrderCreatedProducer>();
+        services.AddSingleton<IOrderCacheProducer, KafkaOrderCacheProducer>();
         services.AddSingleton<IEmailProducer, KafkaEmailProducer>();
         services.AddHostedService<CartCheckoutConsumer>();
         services.AddHostedService<OrderPaidConsumer>();

--- a/OrderService/OrderService.Infrastructure/Messaging/KafkaOrderCacheProducer.cs
+++ b/OrderService/OrderService.Infrastructure/Messaging/KafkaOrderCacheProducer.cs
@@ -1,0 +1,33 @@
+using Confluent.Kafka;
+using Microsoft.Extensions.Configuration;
+using OrderService.Application.DTO;
+using OrderService.Application.Interfaces;
+using System.Text.Json;
+
+namespace OrderService.Infrastructure.Messaging;
+
+public class KafkaOrderCacheProducer : IOrderCacheProducer, IDisposable
+{
+    private readonly IProducer<Null, string> _producer;
+    private readonly string _topic;
+
+    public KafkaOrderCacheProducer(IConfiguration configuration)
+    {
+        var bootstrap = configuration["Kafka:BootstrapServers"] ?? "kafka:9092";
+        _topic = configuration["Kafka:OrderCacheTopic"] ?? "order-cache";
+        var config = new ProducerConfig { BootstrapServers = bootstrap };
+        _producer = new ProducerBuilder<Null, string>(config).Build();
+    }
+
+    public async Task PublishAsync(OrderCacheEvent cache, CancellationToken ct = default)
+    {
+        var json = JsonSerializer.Serialize(cache);
+        await _producer.ProduceAsync(_topic, new Message<Null, string> { Value = json }, ct);
+    }
+
+    public void Dispose()
+    {
+        _producer.Flush();
+        _producer.Dispose();
+    }
+}

--- a/OrderService/OrderService/Program.cs
+++ b/OrderService/OrderService/Program.cs
@@ -5,6 +5,10 @@ using Microsoft.OpenApi.Models;
 using OrderService.Application.Extensions;
 using OrderService.Infrastructure.Extensions;
 using OrderService.Infrastructure.Data;
+using OrderService.Application.Interfaces;
+using OrderService.Application.DTO;
+using OrderService.Domain.Repositories;
+using System.Linq;
 using System.Reflection;
 using Hellang.Middleware.ProblemDetails;
 using Microsoft.AspNetCore.Diagnostics;
@@ -15,7 +19,7 @@ namespace OrderService
 {
     public class Program
     {
-        public static void Main(string[] args)
+        public static async Task Main(string[] args)
         {
             var builder = WebApplication.CreateBuilder(args);
 
@@ -117,7 +121,13 @@ namespace OrderService
             using (var scope = app.Services.CreateScope())
             {
                 var db = scope.ServiceProvider.GetRequiredService<OrdersDbContext>();
-                db.Database.Migrate();
+                await db.Database.MigrateAsync();
+
+                var repo = scope.ServiceProvider.GetRequiredService<IOrderRepository>();
+                var producer = scope.ServiceProvider.GetRequiredService<IOrderCacheProducer>();
+                var orders = await repo.GetAllAsync();
+                var map = orders.ToDictionary(o => o.Id, o => o.UserId);
+                await producer.PublishAsync(new OrderCacheEvent { Orders = map });
             }
 
             app.UseCors();
@@ -131,7 +141,7 @@ namespace OrderService
             app.UseAuthorization();
             app.MapControllers();
 
-            app.Run();
+            await app.RunAsync();
         }
     }
 }

--- a/PaymentService/Cache/IOrderCache.cs
+++ b/PaymentService/Cache/IOrderCache.cs
@@ -5,6 +5,7 @@ namespace PaymentService.Cache;
 public interface IOrderCache
 {
     IReadOnlyDictionary<Guid, Guid> Orders { get; }
+    void Set(Messaging.OrderCacheEvent cache);
     bool Contains(Guid orderId);
     Guid? GetUserId(Guid orderId);
     void Add(Guid orderId, Guid userId);

--- a/PaymentService/Cache/OrderCache.cs
+++ b/PaymentService/Cache/OrderCache.cs
@@ -9,6 +9,15 @@ public class OrderCache : IOrderCache
 
     public IReadOnlyDictionary<Guid, Guid> Orders => _orders;
 
+    public void Set(Messaging.OrderCacheEvent cache)
+    {
+        _orders.Clear();
+        foreach (var kvp in cache.Orders)
+        {
+            _orders[kvp.Key] = kvp.Value;
+        }
+    }
+
     public bool Contains(Guid orderId) => _orders.ContainsKey(orderId);
 
     public Guid? GetUserId(Guid orderId) => _orders.TryGetValue(orderId, out var userId) ? userId : null;

--- a/PaymentService/Messaging/OrderCacheConsumer.cs
+++ b/PaymentService/Messaging/OrderCacheConsumer.cs
@@ -1,0 +1,72 @@
+using Confluent.Kafka;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using PaymentService.Cache;
+using System.Text.Json;
+
+namespace PaymentService.Messaging;
+
+public class OrderCacheConsumer : BackgroundService
+{
+    private IConsumer<Ignore, string>? _consumer;
+    private readonly string _topic;
+    private readonly IConfiguration _configuration;
+    private readonly IOrderCache _cache;
+    private readonly ILogger<OrderCacheConsumer> _logger;
+
+    public OrderCacheConsumer(IConfiguration configuration, IOrderCache cache, ILogger<OrderCacheConsumer> logger)
+    {
+        _configuration = configuration;
+        _cache = cache;
+        _logger = logger;
+        _topic = configuration["Kafka:OrderCacheTopic"] ?? "order-cache";
+    }
+
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var config = new ConsumerConfig
+        {
+            GroupId = "paymentservice-cache",
+            BootstrapServers = _configuration["Kafka:BootstrapServers"] ?? "kafka:9092",
+            AutoOffsetReset = AutoOffsetReset.Earliest,
+            EnableAutoCommit = true
+        };
+
+        _ = Task.Run(async () =>
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    _logger.LogInformation("Connecting to Kafka {Broker}...", config.BootstrapServers);
+                    _consumer = new ConsumerBuilder<Ignore, string>(config).Build();
+                    _consumer.Subscribe(_topic);
+
+                    while (!stoppingToken.IsCancellationRequested)
+                    {
+                        var result = _consumer.Consume(stoppingToken);
+                        var evt = JsonSerializer.Deserialize<OrderCacheEvent>(result.Message.Value);
+                        if (evt != null)
+                        {
+                            _cache.Set(evt);
+                            _logger.LogInformation("Order cache loaded with {Count} entries", evt.Orders.Count);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Kafka consumer error. Retrying in 5s...");
+                    await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+                }
+                finally
+                {
+                    _consumer?.Close();
+                    _consumer?.Dispose();
+                }
+            }
+        }, stoppingToken);
+
+        return Task.CompletedTask;
+    }
+}

--- a/PaymentService/Messaging/OrderCacheEvent.cs
+++ b/PaymentService/Messaging/OrderCacheEvent.cs
@@ -1,0 +1,6 @@
+namespace PaymentService.Messaging;
+
+public class OrderCacheEvent
+{
+    public Dictionary<Guid, Guid> Orders { get; set; } = new();
+}

--- a/PaymentService/Program.cs
+++ b/PaymentService/Program.cs
@@ -97,6 +97,7 @@ builder.Services.AddProblemDetails(options =>
 builder.Services.AddSingleton<IOrderPaidProducer, KafkaOrderPaidProducer>();
 builder.Services.AddSingleton<PaymentService.Cache.IOrderCache, PaymentService.Cache.OrderCache>();
 builder.Services.AddHostedService<PaymentService.Messaging.OrderCreatedConsumer>();
+builder.Services.AddHostedService<PaymentService.Messaging.OrderCacheConsumer>();
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Summary
- initialize order cache on startup via `OrderCacheEvent`
- add Kafka producer and consumer for order cache
- register the new producer and consumer services
- extend interfaces and cache implementations
- add `KAFKA_ORDER_CACHE_TOPIC` variable

## Testing
- `dotnet test CatalogService/CatalogService.UnitTests/CatalogService.UnitTests.csproj` *(fails: The argument ... is invalid)*
- `dotnet build TeaShopService.sln` *(fails: build cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6856cf3474ec8333bac358a488b7f0ba